### PR TITLE
Fix ipsecPolicies output

### DIFF
--- a/scripts/azurerm_virtual_network_gateway_connection.py
+++ b/scripts/azurerm_virtual_network_gateway_connection.py
@@ -110,10 +110,22 @@ def azurerm_virtual_network_gateway_connection(crf,cde,crg,headers,requests,sub,
             if jcount > 0 :
                 for j in range(0,jcount):
                     fr.write('\t ipsec_policy {' + '\n')
-                    
                     dhg= ipsec[j]["dhGroup"]
-                    fr.write('\t dh_group {' + dhg + '"\n')
-                ####  more here  ?    
+                    ikee= ipsec[j]["ikeEncryption"]
+                    ikei= ipsec[j]["ikeIntegrity"]
+                    ipsece= ipsec[j]["ipsecEncryption"]
+                    ipseci= ipsec[j]["ipsecIntegrity"]
+                    pfsg= ipsec[j]["pfsGroup"]
+                    sadata= ipsec[j]["saDataSizeKilobytes"]
+                    salife= ipsec[j]["saLifeTimeSeconds"]
+                    fr.write('\t dh_group = "' + dhg + '"\n')
+                    fr.write('\t ike_encryption = "' + ikee + '"\n')
+                    fr.write('\t ike_integrity = "' + ikei + '"\n')
+                    fr.write('\t ipsec_encryption = "' + ipsece + '"\n')
+                    fr.write('\t ipsec_integrity = "' + ipseci + '"\n')
+                    fr.write('\t pfs_group = "' + pfsg + '"\n')
+                    fr.write('\t sa_datasize = "' + sadata + '"\n')
+                    fr.write('\t sa_lifetime = "' + salife + '"\n')
                     fr.write('\t}\n')
                 
     


### PR DESCRIPTION
Added the additional properties that were missing and corrected the syntax of the output (as the .tf file was malformed previously and threw an error in terraform). 
Note: I have not extensively tested this code, but in my azure resource all of the properties existed. I'm not sure if they will always exist. Regardless, the above amended code results in a valid .tf file that terraform was able to read and no chnages are reported by a terraform plan