### PR TITLE
Various fixes

### DIFF
--- a/scripts/azurerm_express_route_circuit_authorization.py
+++ b/scripts/azurerm_express_route_circuit_authorization.py
@@ -60,7 +60,7 @@ def azurerm_express_route_circuit_authorization(crf,cde,crg,headers,requests,sub
     # no tags       
  
 
-            fr.write('}\n') 
+                fr.write('}\n')
             fr.close()   # close .tf file
 
             if cde:

--- a/scripts/azurerm_network_security_group.py
+++ b/scripts/azurerm_network_security_group.py
@@ -58,7 +58,7 @@ def azurerm_network_security_group(crf,cde,crg,headers,requests,sub,json,az2tfme
                 fr.write('\t\t name = "' +  srname + '"\n')
                 try:
                     srdesc=srules[j]["properties"]["description"]                    
-                    fr.write('\t\t description = "' + srdesc + '"\n')
+                    fr.write('\t\t description = "' + repr(srdesc) + '"\n')
                 except KeyError:
                     pass
 

--- a/scripts/azurerm_resource_group.py
+++ b/scripts/azurerm_resource_group.py
@@ -32,7 +32,7 @@ def azurerm_resource_group(crf,cde,crg,headers,requests,sub,json,az2tfmess):
             loc=rgs[j]["location"]
             id=rgs[j]["id"]
             if crg is not None:
-                if rgs.lower() != crg.lower():
+                if name.lower() != crg.lower():
                     continue
             
             rname=name.replace(".","-")


### PR DESCRIPTION
Changes:
- When specifying a resource group on the command line, the code loops through the discovered resource groups and tries to compare the user specified RG with the _entire list_ of discovered ones each time. It initially fails when trying to set list of RGs to lower case.
- When generating tf file for Express Route Circuit Authorizations, it writes a closing brace whether or not any are discovered. Fix simply indents the code to only output if any discovered.
- When generating tf file for NSGs, a description containing \n will cause it to write a newline rather than the raw text. Fix is to get raw representation of description to write.