### PR TITLE
issue #51,52,53: Various Fixes

### DIFF
--- a/scripts/azurerm_role_definition.py
+++ b/scripts/azurerm_role_definition.py
@@ -62,7 +62,7 @@ def azurerm_role_definition(crf,cde,crg,headers,requests,sub,json,az2tfmess,cldu
             nactions=azr[i]["properties"]["permissions"][0]["notActions"]
 
             #fr.write('role_definition_id = "' + rdid +  '"\n')
-            fr.write('description =  "' +desc + '"\n')
+            fr.write('description =  "' + str(desc) + '"\n')
             #fr.write('scope = "'\{'data.azurerm_subscription.primary.id}'"'  '"\n')
             #fr.write('scope = "'/subscriptions/"' rgsource '"\n')
             fr.write('assignable_scopes = ' + scopes + '\n')

--- a/scripts/azurerm_virtual_machine_scale_set.py
+++ b/scripts/azurerm_virtual_machine_scale_set.py
@@ -174,7 +174,10 @@ def azurerm_virtual_machine_scale_set(crf,cde,crg,headers,requests,sub,json,az2t
 
                             ipcsrg = azr[i]["properties"]["virtualMachineProfile"]["networkProfile"]["networkInterfaceConfigurations"][j]["properties"]["ipConfigurations"][k]["properties"]["subnet"]["id"].split("/")[4].replace(".", "-").lower()
                             ipcsn = azr[i]["properties"]["virtualMachineProfile"]["networkProfile"]["networkInterfaceConfigurations"][j]["properties"]["ipConfigurations"][k]["properties"]["subnet"]["id"].split("/")[10].replace(".", "-")
-                            beapids = azr[i]["properties"]["virtualMachineProfile"]["networkProfile"]["networkInterfaceConfigurations"][j]["properties"]["ipConfigurations"][k]["properties"]["loadBalancerBackendAddressPools"]
+                            try:
+                                beapids = azr[i]["properties"]["virtualMachineProfile"]["networkProfile"]["networkInterfaceConfigurations"][j]["properties"]["ipConfigurations"][k]["properties"]["loadBalancerBackendAddressPools"]
+                            except KerError:
+                                beapids = ""
                             #natrids = azr[i]["properties"]["virtualMachineProfile"]["networkProfile"]["networkInterfaceConfigurations"][j]["properties"]["ipConfigurations"][k]["properties"]["loadBalancerInboundNatPools"]
 
                             fr.write('\t\tname = "' + ipcn + '"\n')
@@ -197,7 +200,7 @@ def azurerm_virtual_machine_scale_set(crf,cde,crg,headers,requests,sub,json,az2t
 
     # storage_profile_os_disk  block
             try:
-                vmosdiskname = azr[i]["properties"]["virtualMachineProfile"]["storageProfile"]["osDisk"]["name"]
+                vmosdiskname = ""
                 vmosdiskcache = azr[i]["properties"]["virtualMachineProfile"]["storageProfile"]["osDisk"]["caching"]
                 vmoscreoption = azr[i]["properties"]["virtualMachineProfile"]["storageProfile"]["osDisk"]["createOption"]
 

--- a/scripts/azurerm_virtual_machine_scale_set.py
+++ b/scripts/azurerm_virtual_machine_scale_set.py
@@ -200,7 +200,10 @@ def azurerm_virtual_machine_scale_set(crf,cde,crg,headers,requests,sub,json,az2t
 
     # storage_profile_os_disk  block
             try:
-                vmosdiskname = ""
+                try:
+                    vmosdiskname = azr[i]["properties"]["virtualMachineProfile"]["storageProfile"]["osDisk"]["name"]
+                except KeyError:
+                    vmosdiskname = ""
                 vmosdiskcache = azr[i]["properties"]["virtualMachineProfile"]["storageProfile"]["osDisk"]["caching"]
                 vmoscreoption = azr[i]["properties"]["virtualMachineProfile"]["storageProfile"]["osDisk"]["createOption"]
 

--- a/scripts/azurerm_virtual_machine_scale_set.py
+++ b/scripts/azurerm_virtual_machine_scale_set.py
@@ -176,7 +176,7 @@ def azurerm_virtual_machine_scale_set(crf,cde,crg,headers,requests,sub,json,az2t
                             ipcsn = azr[i]["properties"]["virtualMachineProfile"]["networkProfile"]["networkInterfaceConfigurations"][j]["properties"]["ipConfigurations"][k]["properties"]["subnet"]["id"].split("/")[10].replace(".", "-")
                             try:
                                 beapids = azr[i]["properties"]["virtualMachineProfile"]["networkProfile"]["networkInterfaceConfigurations"][j]["properties"]["ipConfigurations"][k]["properties"]["loadBalancerBackendAddressPools"]
-                            except KerError:
+                            except KeyError:
                                 beapids = ""
                             #natrids = azr[i]["properties"]["virtualMachineProfile"]["networkProfile"]["networkInterfaceConfigurations"][j]["properties"]["ipConfigurations"][k]["properties"]["loadBalancerInboundNatPools"]
 


### PR DESCRIPTION
**Errors**
1. desc in azurerm_role_definition.py fails with NoneType when description does not exist
2. KeyError in azurerm_virtual_machine_scale_set.py when loadBalancerBackendAddressPools does not exist
3. terraform validate fails because storage_profile_os_disk block is not created 

**Fix**
1. typecast desc to str
2. try except block for loadBalancerBackendAddressPools
3. set storage profile name as empty string since property is not returned in api request
 




desc in role definitioin fails with NoneType when does not exist


…e error, KeyError Exception Handling for loadBalancerBackendAddressPools and make storage profile name empty string in azurerm_virtual_machine_scale_set.py